### PR TITLE
Fix example for a cache file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ configuration.
 
 Here's how to find the path to a cache file with the name `myCache`:
 
-    File cacheFile = new File(BaseDirectory.get(BaseDirectory.XDG_CONFIG_HOME), "myCache");
+    File cacheFile = new File(BaseDirectory.get(BaseDirectory.XDG_CACHE_HOME), "myCache");
 
     
 ### The [Desktop Entry Specification](http://www.freedesktop.org/wiki/Specifications/desktop-entry-spec/)


### PR DESCRIPTION
The example used the wrong directory; XDG_CACHE_HOME is the correct location for cache files.
